### PR TITLE
Changed documentation example from $elements to $parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ use Goez\PageObjects\Page;
 
 class Home extends Page
 {
-    protected $elements = [
+    protected $parts = [
         'SearchForm' => ['css' => 'form'],
     ];
 


### PR DESCRIPTION
Since the code doesn't seem to do anything with `$elements`, but using `$parts` instead works as expected.
